### PR TITLE
Created a geolocation stimulus controller

### DIFF
--- a/app/javascript/controllers/geolocation_controller.js
+++ b/app/javascript/controllers/geolocation_controller.js
@@ -1,0 +1,16 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="geolocation"
+export default class extends Controller {
+  connect() {
+    const geo = navigator.geolocation
+    geo.watchPosition(this.#getLatLng.bind(this))
+  }
+
+  #getLatLng(location) {
+    const lat = location.coords.latitude
+    const lng = location.coords.longitude
+
+    console.log(lat, lng)
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,5 +4,8 @@
 
 import { application } from "./application"
 
+import GeolocationController from "./geolocation_controller"
+application.register("geolocation", GeolocationController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)


### PR DESCRIPTION
The controller once connected will watch the user's position and will trigger the getLatLng method everytime the user's position changes.
This requires the user to allow the website to track his position like this
![image](https://user-images.githubusercontent.com/75388869/223722206-764d1d8d-ccf0-4328-994d-4d406fcf72c8.png)

I'd like to see if there's a way to style this alert to explain why we need the position eventually but that'll be for later.