### PR TITLE
Photo bug fix

### DIFF
--- a/app/controllers/histories_controller.rb
+++ b/app/controllers/histories_controller.rb
@@ -74,8 +74,8 @@ class HistoriesController < ApplicationController
     return nil unless data
 
     monument = Monument.new(data[:params])
-    attach_photo_to_monument(monument, data[:photo_url])
-    fetch_geocoder_for_monument_update(monument)
+    monument.attach_photo(data[:photo_url]) if data[:photo_url]
+    monument.fetch_geocoder
 
     return monument if monument.save
 
@@ -135,29 +135,5 @@ class HistoriesController < ApplicationController
     return nil unless uri.is_a?(URI::HTTP) && !uri.host.nil?
 
     url
-  end
-
-  def attach_photo_to_monument(monument, photo_url)
-    photo = URI.parse(photo_url).open
-    if photo.size > 26_214_400
-      photo = compress_photo(photo, 40)
-    elsif photo.size > 5_242_880
-      photo = compress_photo(photo, 80)
-    end
-
-    monument.photo.attach(io: photo, filename: "#{monument.name}.jpeg", content_type: "image/jpeg")
-  end
-
-  def compress_photo(photo, quality)
-    image = MiniMagick::Image.new(photo.path)
-    image.combine_options { |o| o.quality quality }
-    StringIO.open(image.to_blob)
-  end
-
-  def fetch_geocoder_for_monument_update(monument)
-    geocoder = Geocoder.search("#{monument.lat},#{monument.lng}").first
-    monument.city = geocoder.city
-    monument.country = geocoder.country
-    monument.country_code = geocoder.country_code.upcase
   end
 end

--- a/app/models/monument.rb
+++ b/app/models/monument.rb
@@ -5,6 +5,10 @@ class Monument < ApplicationRecord
   reverse_geocoded_by :lat, :lng, address: :location
   after_validation :reverse_geocode
 
-  validates :name, :description, :lat, :lng, :city, :country, :country_code, :photo, presence: true
+  validates :name, :description, :lat, :lng, :city, :country, :country_code, presence: true
   validates :lat, :lng, numericality: { only_float: true }
+
+  def self.with_missing_photo
+    Monument.all.reject { |monument| monument.photo.attached? }
+  end
 end

--- a/app/models/monument.rb
+++ b/app/models/monument.rb
@@ -11,4 +11,30 @@ class Monument < ApplicationRecord
   def self.with_missing_photo
     Monument.all.reject { |monument| monument.photo.attached? }
   end
+
+  def attach_photo(photo_url)
+    photo = URI.parse(photo_url).open
+    if photo.size > 26_214_400
+      photo = compress_photo(photo, 40)
+    elsif photo.size > 5_242_880
+      photo = compress_photo(photo, 80)
+    end
+
+    self.photo.attach(io: photo, filename: "#{name}.jpeg", content_type: "image/jpeg")
+  end
+
+  def fetch_geocoder
+    geocoder = Geocoder.search("#{lat},#{lng}").first
+    self.city = geocoder.city
+    self.country = geocoder.country
+    self.country_code = geocoder.country_code.upcase
+  end
+
+  private
+
+  def compress_photo(photo, quality)
+    image = MiniMagick::Image.new(photo.path)
+    image.combine_options { |option| option.quality quality }
+    StringIO.open(image.to_blob)
+  end
 end

--- a/app/models/monument.rb
+++ b/app/models/monument.rb
@@ -8,7 +8,7 @@ class Monument < ApplicationRecord
   validates :name, :description, :lat, :lng, :city, :country, :country_code, presence: true
   validates :lat, :lng, numericality: { only_float: true }
 
-  def self.with_missing_photo
+  def self.without_photo
     Monument.all.reject { |monument| monument.photo.attached? }
   end
 

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -13,7 +13,7 @@
     <%= f.label :photo do %>
       <i class="fa-solid fa-camera"></i>
     <% end %>
-    <%= f.file_field :photo, style: "display: none;", accept: "image/*", onchange: "form.submit();" %>
+    <%= f.file_field :photo, style: "display: none;", accept: "image/*", oninput: "form.submit();" %>
   <% end %>
 
   <div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -108,7 +108,7 @@ def create_monument
   puts "#{Time.current - method_start}s to complete attach_photo_to_model(monument)"
 
   method_start = Time.current
-  fetch_geocoder_for_monument_update(monument)
+  monument.fetch_geocoder
   puts "#{Time.current - method_start}s to complete fetch_geocoder_for_monument_update"
 
   method_start = Time.current
@@ -189,13 +189,6 @@ def compress_photo(photo, quality)
   puts "#{Time.current - method_start}s to complete compress_photo"
 
   photo
-end
-
-def fetch_geocoder_for_monument_update(monument)
-  geocoder = Geocoder.search("#{monument.lat},#{monument.lng}").first
-  monument.city = geocoder.city
-  monument.country = geocoder.country
-  monument.country_code = geocoder.country_code.upcase
 end
 
 start = Time.current


### PR DESCRIPTION
The only fix I could think of in case Wikipedia's API doesn't find a main image is to remove the validation for the photo and to have a class method on the Monument model that returns every instances that don't have a photo.
We can then use he #attach_photo instance method to upload a file manually by checking the Monument.without_photo array from time to time.

- It's either that or pick a random image from wikipedia in hope that it's a relevant one which imo is a bad idea
- Or use another API to get an image, probably google search or something like that, and pick the first image in hope it's a relevant one.  It's a compromise I would be willing to take but I ahven't really looked into it.

I also fixed a bug where the camera form would submit even if the user cancel the file file selection. It now submit only once a file has been chosen.