### PR TITLE
Monument duplicate bug fix

### DIFF
--- a/app/controllers/histories_controller.rb
+++ b/app/controllers/histories_controller.rb
@@ -68,7 +68,7 @@ class HistoriesController < ApplicationController
   end
 
   def find_monument_by_landmark
-    Monument.find_by(name: @landmark_name, lat: @landmark_lat, lng: @landmark_lng)
+    Monument.find_by(name: @landmark_name)
   end
 
   def create_monument

--- a/app/controllers/histories_controller.rb
+++ b/app/controllers/histories_controller.rb
@@ -43,7 +43,7 @@ class HistoriesController < ApplicationController
 
     @landmark_lat = landmark.locations.first.lat_lng.latitude
     @landmark_lng = landmark.locations.first.lat_lng.longitude
-    @landmark_name = landmark.description
+    @landmark_name = landmark.description.split.map(&:capitalize).join(" ")
 
     new_history
   end


### PR DESCRIPTION
I removed lat and lng from the Monument.find_by method meaning it's only gonna search by name.

Initially we were also looking for the same coordinates because we wanted to make sure that it was the same monument and not just another one with the same name but in reality that could not happen because if two different monuments had the same name then they would redirect to the same wikipedia page and we would only have informations for one monument, not two.
As such there really isn't a need to search by more than the name because it should be a unique attribute already.