### PR TITLE
Wikipedia coord bug fixed

### DIFF
--- a/app/controllers/histories_controller.rb
+++ b/app/controllers/histories_controller.rb
@@ -87,7 +87,7 @@ class HistoriesController < ApplicationController
 
   def fetch_data_from_wikipedia
     page = Wikipedia.find(@landmark_name)
-    return nil unless page.coordinates
+    return nil unless page.extlinks
 
     { params: {
         name: @landmark_name,


### PR DESCRIPTION
The issue was that sometimes when looking for a wikipedia page we don't end up on an article but in a search result.
For example if we look for "Notre Dame" we end up on this page
https://en.wikipedia.org/wiki/Notre_Dame

To take this into account we had a condition to make sure the page that we get has coordinates, the logic was that only monuments would have them, not a search page
```
    page = Wikipedia.find(@landmark_name)
    return nil unless page.coordinates
```

But apparently not all monuments have coordinates either, like the Taj Mahal's page.
I tried it and the next easy solution I found was to check for external links instead which all the page I tested have but search pages don't
```
    page = Wikipedia.find(@landmark_name)
    return nil unless page.extlinks
```